### PR TITLE
Bump com.github.kt3k.coveralls from 2.6.3 to 2.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'com.github.kt3k.coveralls' version '2.6.3'
+  id 'com.github.kt3k.coveralls' version '2.12.0'
 }
 
 coveralls.jacocoReportPath = 'build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml'


### PR DESCRIPTION
Bumps com.github.kt3k.coveralls from 2.6.3 to 2.12.0.
